### PR TITLE
specify Nstrat when creating integration matrices

### DIFF
--- a/R/create_shell_dataset.R
+++ b/R/create_shell_dataset.R
@@ -92,6 +92,7 @@ create_shell_dataset <- function(survey_circumcision,
     time1 = time1,
     time2 = time2,
     strat = strat,
+    Nstrat = nrow(areas_model),
     age   = age,
     Ntime = length(unique(out$time)),
     ...
@@ -126,6 +127,7 @@ create_shell_dataset <- function(survey_circumcision,
       age   = age,
       circ  = circ,
       Ntime = length(unique(out$time)),
+      Nstrat = nrow(areas_model),
       ...
     )
   })


### PR DESCRIPTION
Explicitly specify `Nstrat` to be the number of areas when constructing integration matrices. 

Previously this was set based on the maximum index for `space` in the circumcision data set. This failed however for Ghana because the `space = 260` does not have any data and therefore the wrong index (259) was selected.

Specifying this explicitly might mess up version of model if it is run without spatial structure.