### PR TITLE
Fix survey reassignment bug

### DIFF
--- a/R/prepare_survey_data.R
+++ b/R/prepare_survey_data.R
@@ -42,55 +42,69 @@ prepare_survey_data <- function(areas,
                                 norm_kisk_weights = TRUE,
                                 strata.norm = c("survey_id", "area_id"),
                                 strata.kish = c("survey_id")) {
-
+  
+  
   # function to parse country specific psnu area levels if desired
   select_area_lev <- function(area_lev, cntry, is_add_data_present) {
-    # if providing fixed area_lev, just return it
+    
+    # if area_lev is provided (i.e as a value, rather than a df), just return 
     if (!inherits(area_lev, "data.frame")) {
       return(area_lev)
-    } else {
-      area_lev <- area_lev %>%
-        dplyr::filter(.data$iso3 == cntry) %>%
-        dplyr::pull(.data$psnu_area_level)
-      # if area_level is missing, assume most common area lev in surveys
-      if (length(area_lev) == 0) {
-        if (is_add_data_present) {
-          area_lev <- table(as.numeric(substr(
-            # "area_id" column in survey_clusters may be "geoloc_area_id"
-            dplyr::pull(
-              survey_clusters[grepl("area_id", names(survey_clusters))]
-            ), 5, 5
-          )))
-        } else {
-          area_lev <- table(as.numeric(
-            substr(survey_circumcision[[i]]$area_id, 5, 5)
-          ))
-        }
-        area_lev <- as.numeric(names(area_lev)[area_lev == max(area_lev)])
-      }
-      return(area_lev)
+    } 
+    # if area_lev is a df (i.e. threemc::datapack_psnu_area_level) ...
+    
+    # find area_level for specified country from area_lev df
+    area_lev <- area_lev %>%
+      dplyr::filter(.data$iso3 == cntry) %>%
+      dplyr::pull(.data$psnu_area_level)
+    
+    # if area_lev for specified cntry is present in df, return 
+    if (length(area_lev) == 1) return(area_lev)
+    
+    # if area_level for cntry is missing, assume most common lev in surveys
+    if (length(area_lev) == 0 && is_add_data_present) {
+      # If survey_clusters is specified, find most common area level there
+      area_lev_df <- survey_clusters
+    } else if (length(area_lev) == 0) {
+      # otherwise, use most common area level in survey_circumcision
+      area_lev_df <- survey_circumcision
     }
+    
+    # pull area_level from area_id col (area_level column not guaranteed)
+    area_levs <- area_lev_df %>% 
+      dplyr::filter(.data$iso3 == cntry) %>% 
+      dplyr::select(contains("area_id")) %>% 
+      pull() %>% 
+      substr(5, 5) # i.e. LSO_1_01 gives area_level 1
+    
+    # tabulate and return most common level (i.e. with max count in table)
+    area_levs_tbl <- table(area_levs)
+    area_lev <- as.numeric(
+      names(area_levs_tbl)[area_levs_tbl == max(area_levs_tbl)]
+    )
+    
+    return(area_lev)
   }
   
   # if survey_circumcision is a list or contains more than one country,
   # apply function recursively for each iso3
   is_list <- inherits(survey_circumcision, "list")
-
+  
   # Check if cluster & individuals data is provided; if not, assume sufficient
   # data is included in survey_circumcision alone
   is_add_data_present <- !is.null(survey_clusters) &
     !is.null(survey_individuals)
-
+  
   # split based on iso3 if not already a list and containing > 1 country
   if (!is_list && length(unique(survey_circumcision$iso3)) != 1) {
     survey_circumcision <- split(survey_circumcision, survey_circumcision$iso3)
-
+    
     # arrange and filter for country to ensure splitting is the same
     equal_splits <- function(x, survey_circumcision) {
       x <- x[names(x) %chin% names(survey_circumcision)] # same names
       return(x[order(names(survey_circumcision))]) # order names
     }
-
+    
     # If cluster & individuals data are null, splitting would produce an error
     if (is_add_data_present) {
       survey_individuals <- split(survey_individuals, survey_individuals$iso3)
@@ -101,33 +115,33 @@ prepare_survey_data <- function(areas,
       survey_clusters <- equal_splits(survey_clusters, survey_circumcision)
     }
   }
-
+  
   if (inherits(survey_circumcision, "list")) {
     message(paste0(
       "survey_circumcision supplied is a list and/or contains multiple",
       " countries, applying function recursively for each country present"
     ))
-
+    
     # loop over each country
     surveys <- lapply(seq_along(survey_circumcision), function(i) {
-
+      
       # pull country
       cntry <- unique(survey_circumcision[[i]]$iso3)
-
+      
       message("Preparing surveys for ", cntry, "\n")
-
+      
       if (cntry == "LBR" && cens_age > 29) {
         cens_age <- 29
         message("for LBR, age must be censored to those under 29 (at least)")
       }
-
+      
       # pull latest and first censoring year from survey_id
       survey_years <- as.numeric(substr(unique(
         survey_circumcision[[i]]$survey_id
       ), 4, 7))
       cens_year <- max(survey_years)
       start_year <- max(min(survey_years), start_year)
-
+      
       # filter specific country entries in additional dfs, if they are provided
       if (is_add_data_present) {
         survey_individuals_spec <- dplyr::filter(
@@ -142,7 +156,7 @@ prepare_survey_data <- function(areas,
       survey_circumcision_spec <- dplyr::filter(
         survey_circumcision[[i]], .data$iso3 == cntry
       )
-
+      
       # apply function recursively for each country
       prepare_survey_data(
         areas = dplyr::filter(areas, .data$iso3 == cntry),
@@ -164,7 +178,7 @@ prepare_survey_data <- function(areas,
     names(surveys) <- names(survey_circumcision)
     return(surveys)
   }
-
+  
   # if we set cens_year == TRUE, calculate cens_year as max survey year
   if (!is.null(cens_year) && cens_year == TRUE) {
     message("cens_year set to TRUE, calculated as last survey year")
@@ -177,28 +191,28 @@ prepare_survey_data <- function(areas,
       substr(unique(surveys), 4, 7)
     ))
   }
-
+  
   # remove area_level column if present, to avoid row duplication
   survey_circumcision <- dplyr::select(
     survey_circumcision,
     -dplyr::matches("area_level")
   )
-
-
+  
+  
   # Merging circumcision and individuals survey datasets ---------------------
 
   # pull original surveys
   orig_surveys <- unique(survey_circumcision$survey_id)
-
+  
   # Join survey data sources together, if they been provided as joined already
   if (is_add_data_present) {
-
+    
     # change colnames to those in line with areas
     if ("geoloc_area_id" %chin% names(survey_clusters)) {
       survey_clusters <- survey_clusters %>%
         dplyr::rename(area_id = .data$geoloc_area_id)
     }
-
+    
     # Merging datasets, if required
     survey_circumcision <- survey_circumcision %>%
       # Merging on individual information to  the circumcision dataset
@@ -213,19 +227,19 @@ prepare_survey_data <- function(areas,
       # Merging on cluster information to the circumcision dataset
       dplyr::left_join(
         (survey_clusters %>%
-          dplyr::mutate(area_id = as.character(.data$area_id)) %>%
-          dplyr::select(.data$survey_id, .data$cluster_id, .data$area_id)),
+           dplyr::mutate(area_id = as.character(.data$area_id)) %>%
+           dplyr::select(.data$survey_id, .data$cluster_id, .data$area_id)),
         by = c("survey_id", "cluster_id")
       )
   }
-
+  
   # Add column of NAs for missing age columns
   age_cols <- c("circ_age", "age")
   if (sum(age_cols %chin% names(survey_circumcision)) < 2) {
     missing_age_cols <- age_cols[!age_cols %chin% names(survey_circumcision)]
     survey_circumcision[, missing_age_cols] <- NA
   }
-
+  
   # Remove those with missing circumcison status
   survey_circumcision <- survey_circumcision %>%
     dplyr::filter(
@@ -243,9 +257,9 @@ prepare_survey_data <- function(areas,
       # If circumcision age > age of the individual set, reset circumcision age
       circ_age = ifelse(.data$circ_age > .data$age, NA_real_, .data$circ_age)
     )
-
+  
   # Censoring if necessary ---------------------------------------------------
-
+  
   # Censoring at cens_year if assumed no circumcisions after a certain year
   if (!is.null(cens_age)) {
     survey_circumcision <- survey_circumcision %>%
@@ -253,23 +267,23 @@ prepare_survey_data <- function(areas,
       dplyr::mutate(
         # No circumcision after cens_age
         circ_status = ifelse(.data$circ_status == 1 &
-          !is.na(.data$circ_age) &
-          .data$circ_age > cens_age, 0, .data$circ_status),
+                               !is.na(.data$circ_age) &
+                               .data$circ_age > cens_age, 0, .data$circ_status),
         # Resetting age at circumcision
         circ_age = ifelse(.data$circ_age > cens_age, NA,
-          .data$circ_age
+                          .data$circ_age
         ),
         # Resetting age for everyone else
         age = ifelse(.data$age > cens_age, cens_age,
-          .data$age
+                     .data$age
         ),
         # Year of circ/censoring (estimated using the age as no date of circ)
         yoc = ifelse(!is.na(.data$circ_age), .data$yob + .data$circ_age,
-          .data$yob + .data$age
+                     .data$yob + .data$age
         )
       )
   }
-
+  
   # Censoring at cens_year if assumed no circumcisions after a certain year
   if (!is.null(cens_year)) {
     survey_circumcision <- survey_circumcision %>%
@@ -358,18 +372,18 @@ prepare_survey_data <- function(areas,
   message(
     paste0(utils::capture.output(event_tbl), collapse = "\n")
   )
-
+  
   # Adding circumcision type to dataset
   survey_circumcision <- survey_circumcision %>%
     # Type of circumcision
     dplyr::mutate(
       circ_who = ifelse(.data$circ_who == "other",
-        NA_character_,
-        .data$circ_who
+                        NA_character_,
+                        .data$circ_who
       ),
       circ_where = ifelse(.data$circ_where == "other",
-        NA_character_,
-        .data$circ_where
+                          NA_character_,
+                          .data$circ_where
       ),
       type = dplyr::case_when(
         .data$circ_who == "medical" | .data$circ_where == "medical" ~ "MMC",
@@ -378,7 +392,7 @@ prepare_survey_data <- function(areas,
         TRUE ~ "Missing"
       )
     )
-
+  
   # Get surveys without any type information
   if (rm_missing_type == TRUE) {
     tmp <- with(
@@ -389,7 +403,7 @@ prepare_survey_data <- function(areas,
       dplyr::group_by(.data$survey_id) %>%
       dplyr::mutate(Freq = .data$Freq / sum(.data$Freq)) %>%
       dplyr::filter(.data$type == "Missing", .data$Freq == 1)
-
+    
     # return message detailing all surveys which are missing
     n <- nrow(tmp)
     if (n > 0) {
@@ -403,8 +417,8 @@ prepare_survey_data <- function(areas,
         message(
           paste0(
             paste(paste(survey_id[1:(n - 1)], collapse = ", "),
-              survey_id[n],
-              sep = " & "
+                  survey_id[n],
+                  sep = " & "
             ),
             " have all type == \"Missing\", and will be removed"
           )
@@ -418,7 +432,7 @@ prepare_survey_data <- function(areas,
         !(.data$circ_status == 1 & .data$type == "Missing")
       )
   }
-
+  
   # normalise survey weights and apply Kish coefficients, if desired
   if (norm_kisk_weights) {
     survey_circumcision <- normalise_weights_kish(
@@ -427,7 +441,7 @@ prepare_survey_data <- function(areas,
       strata.kish = strata.kish
     )
   }
-
+  
   # return message for which surveys are discarded & kept (if any)
   remaining_surveys <- unique(survey_circumcision$survey_id)
   if (length(remaining_surveys) != length(orig_surveys)) {
@@ -454,7 +468,7 @@ prepare_survey_data <- function(areas,
       }
     }))
   }
-
+  
   # Returning prepped circumcision datasets
   return(survey_circumcision)
 }


### PR DESCRIPTION
Fix bug whereby surveys not at PSNU area level were having their area_id coerced to NA
Surveys where this occured: 
"BEN2006DHS"  "BEN2014MICS" "GHA2017MICS" "MOZ2003DHS"  "TCD2004DHS"  "TZA2004DHS"  "ZWE2014MICS"
Rerunning for these countries should see more data being fed into the model